### PR TITLE
Fix recurring events not showing correct dates

### DIFF
--- a/scripts/listEvents.vbs
+++ b/scripts/listEvents.vbs
@@ -50,7 +50,7 @@ Function GetCalendarEvents(startDate, endDate, calendarName)
     On Error Resume Next
     
     ' Create Outlook objects
-    Dim outlookApp, calendar, filter, events
+    Dim outlookApp, calendar, filter, events, allItems
     
     ' Create Outlook application
     Set outlookApp = CreateOutlookApplication()
@@ -62,15 +62,20 @@ Function GetCalendarEvents(startDate, endDate, calendarName)
         Set calendar = GetCalendarByName(outlookApp, calendarName)
     End If
     
+    ' CRITICAL: Must be in this exact order for recurring events:
+    ' 1. Get Items collection
+    ' 2. Sort by [Start]
+    ' 3. Set IncludeRecurrences = True
+    ' 4. Then filter with Restrict
+    Set allItems = calendar.Items
+    allItems.Sort "[Start]"
+    allItems.IncludeRecurrences = True
+    
     ' Create filter for date range
-    ' Format: "[Start] >= '2/2/2009 12:00 AM' AND [End] <= '2/3/2009 12:00 AM'"
-    filter = "[Start] >= '" & FormatDate(startDate) & " 12:00 AM' AND [End] <= '" & FormatDate(DateAdd("d", 1, endDate)) & " 12:00 AM'"
+    filter = "[Start] >= '" & FormatDate(startDate) & " 12:00 AM' AND [Start] <= '" & FormatDate(DateAdd("d", 1, endDate)) & " 12:00 AM'"
     
     ' Get events matching the filter
-    Set events = calendar.Items.Restrict(filter)
-    
-    ' Sort by start date
-    events.Sort "[Start]"
+    Set events = allItems.Restrict(filter)
     
     If Err.Number <> 0 Then
         OutputError "Failed to get calendar events: " & Err.Description

--- a/scripts/utils.vbs
+++ b/scripts/utils.vbs
@@ -306,17 +306,19 @@ End Function
 
 ' Converts a collection of Outlook appointment items to a JSON array
 Function AppointmentsToJSON(appointments)
-    Dim i, json
-    
+    Dim json, appointment, first
+
     json = "["
-    
-    For i = 1 To appointments.Count
-        If i > 1 Then json = json & ","
-        json = json & AppointmentToJSON(appointments.Item(i))
+    first = True
+
+    For Each appointment In appointments
+        If Not first Then json = json & ","
+        json = json & AppointmentToJSON(appointment)
+        first = False
     Next
-    
+
     json = json & "]"
-    
+
     AppointmentsToJSON = json
 End Function
 


### PR DESCRIPTION
- Sort by [Start] before setting IncludeRecurrences = True, then Restrict (Microsoft requires this exact order for recurring event expansion)
- Change filter from [End] to [Start] for upper bound to catch events that start in range but end after it
- Replace appointments.Count loop with For Each in AppointmentsToJSON (Count is unreliable/infinite with IncludeRecurrences = True)